### PR TITLE
Allow accessing a profile by specifying a Discord username

### DIFF
--- a/app/controllers/api.controller.ts
+++ b/app/controllers/api.controller.ts
@@ -115,5 +115,19 @@ router.get('/gauntlet_info', async (req: Request, res: Response, next) => {
 	}
 });
 
+router.get('/get_dbid_from_discord', async (req: Request, res: Response, next) => {
+	if (!req.query || !req.query.username || !req.query.discriminator) {
+		res.status(400).send('Whaat?');
+		return;
+	}
+
+	try {
+		let apiResult = await DataCoreAPI.getDBIDbyDiscord(req.query.username.toString(), req.query.discriminator.toString());
+		res.status(apiResult.Status).send(apiResult.Body);
+	} catch (e) {
+		next(e);
+	}
+});
+
 // Export the express.Router() instance to be used by server.ts
 export const ApiController: Router = router;

--- a/app/logic/api.ts
+++ b/app/logic/api.ts
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 import { sign, verify } from 'jsonwebtoken';
 
 import { Logger, LogData } from './logger';
-import { uploadProfile, loadProfileCache, loginUser } from './profiletools';
+import { uploadProfile, loadProfileCache, loginUser, getDBIDbyDiscord } from './profiletools';
 import { loadCommentsDB, saveCommentDB } from './commenttools';
 
 require('dotenv').config();
@@ -206,6 +206,25 @@ export class ApiClass {
 			Body: comments
 		};
 	}
+
+	async getDBIDbyDiscord(discordUserName: string, discordUserDiscriminator: string): Promise<ApiResult> {
+		Logger.info('Get dbid for Discord user', { discordUserName, discordUserDiscriminator });
+
+		let dbid = await getDBIDbyDiscord(discordUserName, discordUserDiscriminator);
+
+		if (dbid) {
+			return {
+				Status: 200,
+				Body: JSON.stringify({ dbid }),
+			}
+		} else {
+			return {
+				Status: 404,
+				Body: JSON.stringify({ error: 'No DBID found for Discord user' }),
+			}
+		}
+	}
+
 }
 
 export let DataCoreAPI = new ApiClass();

--- a/app/logic/profiletools.ts
+++ b/app/logic/profiletools.ts
@@ -98,3 +98,12 @@ export async function addBookUser(loginUserName: string, password: string) {
 
 	return res;
 }
+
+export async function getDBIDbyDiscord(discordUserName: string, discordUserDiscriminator: string) {
+	let user = await User.findOne({ where: { discordUserName, discordUserDiscriminator }, include: [Profile] });
+	if (user && user.profiles && user.profiles.length === 1) {
+		return user.profiles[0].dbid;
+	} else {
+		return undefined;
+	}
+}


### PR DESCRIPTION
A little janky, happy to make changes as desired.

Works with https://github.com/stt-datacore/website/pull/32 to allow website links to view profiles based on Discord username.